### PR TITLE
Fix malformed CSS rule for PostCSS

### DIFF
--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -35,7 +35,7 @@ const AnimatedBackground = () => {
   }, []);
 
   return (
-
+    <div ref={ref} className="absolute inset-0">
       <div className="absolute inset-0 animated-gradient" />
       <div className="absolute inset-0 apple-fluid-bg" />
       <div className="absolute inset-0 apple-overlay" />

--- a/src/index.css
+++ b/src/index.css
@@ -154,15 +154,15 @@ All colors MUST be HSL.
   .transition-smooth {
     transition: var(--transition-smooth);
   }
-  
-    .transition-bounce {
-      transition: var(--transition-bounce);
-    }
 
-    /* ====== ELEGANT FLOWING MOTION BACKGROUNDS ====== */
-  
-    /* Deep Purple & Midnight Blue Flowing Gradient */
-    .animated-gradient {
+  .transition-bounce {
+    transition: var(--transition-bounce);
+  }
+
+  /* ====== ELEGANT FLOWING MOTION BACKGROUNDS ====== */
+
+  /* Deep Purple & Midnight Blue Flowing Gradient */
+  .animated-gradient {
       background: linear-gradient(135deg,
         hsl(264 83% 25% / 0.25),
         hsl(230 100% 8% / 0.2),


### PR DESCRIPTION
## Summary
- fix AnimatedBackground markup to return a single container div
- clean up index.css around transition-bounce section so PostCSS parses

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68912fc998f08323b5014073cde4ff0e