### PR TITLE
style: enhance not found page with glass effect

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -158,7 +158,11 @@ All colors MUST be HSL.
   .transition-bounce {
     transition: var(--transition-bounce);
   }
-  
+
+  .glass-card {
+    @apply bg-card/60 backdrop-blur-sm border border-border/50;
+  }
+
   /* ====== PREMIUM APPLE-INSPIRED BACKGROUNDS ====== */
   
   /* Main Animated Gradient - Apple Style - Smoother */

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { HeroButton } from "@/components/ui/hero-button";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,13 +13,14 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+    <div className="min-h-screen bg-background relative overflow-hidden flex items-center justify-center">
+      <div className="absolute inset-0 apple-overlay opacity-10"></div>
+      <div className="relative z-10 glass-card p-10 rounded-2xl text-center space-y-6">
+        <h1 className="text-6xl font-bold text-foreground">404</h1>
+        <p className="text-muted-foreground text-lg">אופס! הדף לא נמצא</p>
+        <HeroButton variant="glow" asChild>
+          <a href="/">חזרה לדף הבית</a>
+        </HeroButton>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add reusable `glass-card` style for translucent blur effect
- restyle not found page using new glass-card and existing theme

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: 3 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689291e0538c8323bbd8516ffd774820